### PR TITLE
Weak/strong tags and override regexp patterns config options

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,19 +46,28 @@ def maybeOverwriteField(patterns, i, note1, note2):
             return True
     return False
 
-def maybeGetWeakNote(note1, note2):
-    weak_tags = getUserOption("Weak tags", [])
+
+def noteWithMoreOfTags(tags, note1, note2):
     note1_score = 0
     note2_score = 0
-    for weak_tag in weak_tags:
-        if weak_tag in note1.tags:
+    for tag in tags:
+        if tag in note1.tags:
             note1_score += 1
-        if weak_tag in note2.tags:
+        if tag in note2.tags:
             note2_score += 1
     if note1_score == note2_score:
         return None
     else:
         return note1 if note1_score > note2_score else note2
+
+def maybeGetWeakNote(note1, note2):
+    strong = noteWithMoreOfTags(getUserOption("Strong tags", []), note1, note2)
+    if strong:
+        return note2 if note1 == strong else note1
+    weak = noteWithMoreOfTags(getUserOption("Weak tags", []), note1, note2)
+    if weak:
+        return weak
+    return None
 
 def mergeNotes(note1, note2):
     mw.checkpoint("Merge Notes")

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {"Delete original cards": false,
  "version":1,
- "When identical keep a single field": true
+ "When identical keep a single field": true,
+ "Overwrite patterns": []
 }

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
  "version":1,
  "When identical keep a single field": true,
  "Overwrite patterns": [],
+ "Strong tags": [],
  "Weak tags": []
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {"Delete original cards": false,
  "version":1,
  "When identical keep a single field": true,
- "Overwrite patterns": []
+ "Overwrite patterns": [],
+ "Weak tags": []
 }

--- a/config.md
+++ b/config.md
@@ -4,3 +4,4 @@ The options are:
 * When identical keep a single field: if two merged cards have the same value in both field, don't concatenate those values.
 * Keyboard shortcut: Select notes in browser then press the shortcut to merge the selected notes.
 * Overwrite patterns: RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "[REPLACEME]" to be overwritten, the configuration value would have to look like this: [ "\\[REPLACEME\\]" ].
+* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "Overwrite patterns" takes precedence.

--- a/config.md
+++ b/config.md
@@ -2,3 +2,4 @@ The options are:
 
 * Delete original cards: if True, the original cards are deleted.
 * When identical keep a single field: if two merged cards have the same value in both field, don't concatenate those values.
+* Keyboard shortcut: Select notes in browser then press the shortcut to merge the selected notes.

--- a/config.md
+++ b/config.md
@@ -4,4 +4,5 @@ The options are:
 * When identical keep a single field: if two merged cards have the same value in both field, don't concatenate those values.
 * Keyboard shortcut: Select notes in browser then press the shortcut to merge the selected notes.
 * Overwrite patterns: RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "[REPLACEME]" to be overwritten, the configuration value would have to look like this: [ "\\[REPLACEME\\]" ].
-* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "Overwrite patterns" takes precedence.
+* Strong tags: Notes with any of these tags will have their non-empty fields overwrite any fields in the other note. "Overwrite patterns" takes precedence.
+* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "Overwrite patterns" and "Weak tags" take precedence.

--- a/config.md
+++ b/config.md
@@ -3,3 +3,4 @@ The options are:
 * Delete original cards: if True, the original cards are deleted.
 * When identical keep a single field: if two merged cards have the same value in both field, don't concatenate those values.
 * Keyboard shortcut: Select notes in browser then press the shortcut to merge the selected notes.
+* Overwrite patterns: RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "[REPLACEME]" to be overwritten, the configuration value would have to look like this: [ "\\[REPLACEME\\]" ].

--- a/config.md
+++ b/config.md
@@ -2,7 +2,6 @@ The options are:
 
 * Delete original cards: if True, the original cards are deleted.
 * When identical keep a single field: if two merged cards have the same value in both field, don't concatenate those values.
-* Keyboard shortcut: Select notes in browser then press the shortcut to merge the selected notes.
-* Overwrite patterns: RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "[REPLACEME]" to be overwritten, the configuration value would have to look like this: [ "\\[REPLACEME\\]" ].
-* Strong tags: Notes with any of these tags will have their non-empty fields overwrite any fields in the other note. "Overwrite patterns" takes precedence.
-* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "Overwrite patterns" and "Weak tags" take precedence.
+* Overwrite patterns: Patterns that indicate a field will be replaced by the value from the other note. Uses RegExp syntax, so be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "`[REPLACEME]`" to be overwritten, : the configuration value would have to look like this: `"Overwrite patterns":  [ "\\[REPLACEME\\]" ]`.
+* Strong tags: Notes with any of these tags will have their non-empty fields overwrite any fields in the other note. "`Overwrite patterns`" takes precedence.
+* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "`Overwrite patterns`" and "`Weak tags`" take precedence.

--- a/config.schema.json
+++ b/config.schema.json
@@ -21,6 +21,14 @@
       "default": [],
       "description": "RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text \"[REPLACEME]\" to be overwritten, the configuration value would have to look like this: [\"\\\\[REPLACEME\\\\]\"]"
     },
+    "Weak tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. \"Overwrite patterns\" takes precedence."
+    },
     "version": {
       "type": "integer",
       "enum": [1],

--- a/config.schema.json
+++ b/config.schema.json
@@ -13,6 +13,14 @@
       "default": false,
       "description": "if True, the original cards are deleted."
     },
+    "Overwrite patterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text \"[REPLACEME]\" to be overwritten, the configuration value would have to look like this: [\"\\\\[REPLACEME\\\\]\"]"
+    },
     "version": {
       "type": "integer",
       "enum": [1],

--- a/config.schema.json
+++ b/config.schema.json
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "default": [],
-      "description": "RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text \"[REPLACEME]\" to be overwritten, the configuration value would have to look like this: [\"\\\\[REPLACEME\\\\]\"]"
+      "description": "Patterns that indicate a field will be replaced by the value from the other note. Uses RegExp syntax, so be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text \"[REPLACEME]\" to be overwritten, : the configuration value would have to look like this: \"Overwrite patterns\": [\"\\\\[REPLACEME\\\\]\"]"
     },
     "Strong tags": {
       "type": "array",

--- a/config.schema.json
+++ b/config.schema.json
@@ -21,13 +21,21 @@
       "default": [],
       "description": "RegExp patterns that indicate a field will be replaced by the value from the other note. Be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text \"[REPLACEME]\" to be overwritten, the configuration value would have to look like this: [\"\\\\[REPLACEME\\\\]\"]"
     },
+    "Strong tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Strong tags: Notes with any of these tags will have their non-empty fields overwrite any fields in the other note. \"Overwrite patterns\" takes precedence."
+    },
     "Weak tags": {
       "type": "array",
       "items": {
         "type": "string"
       },
       "default": [],
-      "description": "Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. \"Overwrite patterns\" takes precedence."
+      "description": "Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. \"Overwrite patterns\" and \"Strong tags\" take precedence."
     },
     "version": {
       "type": "integer",


### PR DESCRIPTION
This is a more opinionated PR which adds a few options to allow the add-on to automatically decide to overwrite some fields, instead of always appending when the values are not identical. They are useful to simplify merging cards created by different means.

Hopefully the documentation from `config.md` should be enough of an explanation to understand them, please let me know if this isn't the case.

* Overwrite patterns: Patterns that indicate a field will be replaced by the value from the other note. Uses RegExp syntax, so be sure to escape special characters if you want to match them literally. For instance, if you want fields with the text "`[REPLACEME]`" to be overwritten, : the configuration value would have to look like this: `"Overwrite patterns":  [ "\\[REPLACEME\\]" ]`.
* Strong tags: Notes with any of these tags will have their non-empty fields overwrite any fields in the other note. "`Overwrite patterns`" takes precedence.
* Weak tags: Notes with any of these tags will have all their fields be overwritten by non-empty fields in the other note. "`Overwrite patterns`" and "`Weak tags`" take precedence.